### PR TITLE
Refactored code to use nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Ignore Everything
+*
+# Except
+!.gitignore
+!installer_files
+!installer_files/flake.nix
+!installer_files/x86-imagebuilder.sh
+!install.sh
+!packages.txt
+!README.md
+!target.txt
+!uninstall.sh

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# 🚀 Custom OpenWRT x86 Image Build & VM Conversion Script
+# 🚀 Custom OpenWRT x86 Image Build & VM Conversion Script (using nix)
 
 ### A simplfied approach to creating custom OpenWRT firmware images:
 - Manage your own list(s) of OpenWRT packages to install
 - Optionally resize default embedded partitions to unlock extra filesystem storage
 - Optionally convert new OpenWRT builds into into QEMU, Virtualbox, HyperV or VMware virtual machine images
-- Automated installation of all Linux dependencies required to build OpenWRT images
+- Automated installation of all Linux dependencies required to build OpenWRT images using the nix package manager
 
 #### ⚙️ Script Option Prompts
 
@@ -16,27 +16,31 @@
    
    ![image](https://github.com/itiligent/OpenWRT-ImageBuilder/assets/94789708/2f3ff65a-1195-4fd1-bf32-44852cb82acd)
 
-6. When the script completes, your new set of build images is located at `$(pwd)/openwrt_build_output/firmware_images`, and their corresponding converted VM images at `$(pwd)openwrt_build_output/vm`.
+6. When the script completes, your new set of build images is located at `$(pwd)/openwrt_build_output/firmware_images`, and their corresponding converted VM images at `$(pwd)/openwrt_build_output/vm`.
 
 ## 🛠️ Prerequisites
 
-Any recent x86 Debian-flavored OS with sudo installed should work fine. Curl and all image building Linux dependencies are automatically installed on first run.
+Any recent x86 linux should work fine. 
+Installer looks for the nix package manager. If it doesn't find it, it asks you if you want to install it.
+Dependencies are subsequently installed using nix.
 Windows subsystem for Linux users have a few more steps: https://openwrt.org/docs/guide-developer/toolchain/wsl
 
 ## 📖 Instructions
 
 
-1. 📥 Download the image builder script and make it executable:
+1. 📥 Clone the git repo then run the install script:
    ```
-   chmod +x x86-imagebuilder.sh
+   ./install.sh
    ```
+   this will create the `buildimage` script
 
-2. 🛠️ Customize your package list in the `CUSTOM_PACKAGES` section. The included list of packages are examples and can be removed. Ensure each package is compatible with your OpenWRT build target & doesn't conflict with others. *(Search https://openwrt.org/packages/start for your desired package names or use the OpenWRT online firmware selector to check for any package conflicts.)*
+2. 🛠️ Customize your package list in the `packages.txt` file. The included list of packages are examples and can be removed. Ensure each package is compatible with your OpenWRT build target & doesn't conflict with others. *(Search https://openwrt.org/packages/start for your desired package names or use the OpenWRT online firmware selector to check for any package conflicts.)*
 
+3. (ADVANCED) - target platform and architecture can be changed by editing the `target.txt` file 
 
-3. ▶️ Run the script as sudo and follow the setup prompts:
+4. ▶️ Run the `buildimage` script and follow the setup prompts:
    ```
-   sudo ./x86-imagebuilder.sh
+   ./buildimage
    ```
 
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+pushd installer_files || exit
+# Check if nix is installed
+if ! command -v nix &> /dev/null
+then
+    echo "The nix package manager is not installed."
+    read -p "Do you want to install nix? (y/n): " answer
+
+    if [[ "$answer" == "y" || "$answer" == "Y" ]]
+    then
+        echo "Installing nix"
+        curl -sL -o nix-installer https://install.determinate.systems/nix/nix-installer-x86_64-linux
+        chmod +x nix-installer
+        ./nix-installer install
+        echo "Nix installed!"
+    else
+        echo "Unable to proceed."
+        popd
+        exit
+    fi
+fi
+echo "Installing openwrt image builder ..."
+nix build
+popd
+rm -f buildimage
+ln -s "$(readlink installer_files/result)/bin/my-script" buildimage
+echo "Files installed!"
+echo "Now run ./buildimage everytime you want to (re)build an openwrt image."

--- a/installer_files/flake.nix
+++ b/installer_files/flake.nix
@@ -1,0 +1,23 @@
+{
+  description = "Easy OWRT Image Builder";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        my-name = "my-script";
+        my-buildInputs = with pkgs; [ qemu-utils openssl binutils bash gnumake wget curl gnugrep coreutils gnused gzip python3 file ];
+        my-script = (pkgs.writeScriptBin my-name (builtins.readFile ./x86-imagebuilder.sh)).overrideAttrs(old: {
+          buildCommand = "${old.buildCommand}\n patchShebangs $out";
+        });
+      in rec {
+        defaultPackage = packages.my-script;
+        packages.my-script = pkgs.symlinkJoin {
+          name = my-name;
+          paths = [ my-script ] ++ my-buildInputs;
+          buildInputs = [ pkgs.makeWrapper ];
+          postBuild = "wrapProgram $out/bin/${my-name} --prefix PATH : $out/bin";
+        };
+      }
+    );
+}

--- a/packages.txt
+++ b/packages.txt
@@ -1,0 +1,23 @@
+# packages.txt
+# Lines beggining with # are treated as comments
+# Add one package per line e.g.: usbutils
+# Remove a default package with e.g.: -dnsmasq
+blockd
+block-mount
+kmod-fs-ext4
+kmod-usb2
+kmod-usb3
+kmod-usb-storage
+kmod-usb-core
+usbutils
+-dnsmasq
+dnsmasq-full
+luci
+luci-app-ddns
+luci-app-samba4
+luci-app-sqm
+sqm-scripts
+luci-app-attendedsysupgrade
+curl
+nano
+vim

--- a/target.txt
+++ b/target.txt
@@ -1,0 +1,6 @@
+# target.sh
+# Change the below values to suit your target architecture
+# Or leave as is for x86
+TARGET="x86"             # x86, mvebu etc
+ARCH="64"                # 64, cortexa9 etc
+IMAGE_PROFILE="generic"  # x86 = generic, linksys_wrt1900acs etc. For profile options run $SOURCE_DIR/make info

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+echo "Uninstaller for openwrt image builder"
+if [ -e "installer_files/nix-installer" ]; then
+    read -p "Do you want to uninstall nix? (y/n): " answer
+    if [[ "$answer" == "y" || "$answer" == "Y" ]]
+    then
+        echo "Uninstalling nix"
+        installer_files/nix-installer uninstall
+    fi
+fi


### PR DESCRIPTION
Hi just creating a pull request. Have refactored the code to install dependencies using `nix` package manager.
These are the new files:

`install.sh` - installs the dependencies ( and the `nix` package manager if not already on the system).
`uninstall.sh` - uninstalls nix
`packages.txt` - contains list of packages any built image will contain
`target.txt` - contains the target to build (x86 by default)

`installer_files` - directory containing installation files, including:

`x86-imagebuilder.sh` - a slightly modified version of your script
`flake.nix` - this is the nix expression which is used to install the required dependencies (line 9), and copy the x86-imagebuilder.sh to the nix-store (i.e. `/nix/store/...`) where the `install.sh` symlinks it to `buildimage`. 

Features: 

- Only `install.sh` requires sudo permissions. After that everything runs without `sudo` (OpenWRT recommend that the image builder doesn't run under sudo).
- Should work on all x86 linux distros (not just debian).
- User doesn't have to mess with script to modify packages - just the `packages.txt` file
- Target / arch can be modified by editing `target.txt`
- I've added a `.gitignore` file to ignore all files and track only the files in the current repo. This way you can clone the repo, build stuff in it, and still push back to git.
- Have edited the README to reflect changes

Hope it's ok. Let me know if any issues! 
Many thanks

