### PR TITLE
fix: remove python3-distutils from APT bc depreceated since 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,21 +73,15 @@ Alternately, in Luci see http://your-routername/cgi-bin/luci/admin/system/mounts
 4. Update to this new build
 
 ## 🌐 Sysupgrades with x86
-   -  OpenWRT Image Builder for x86 **does not support sysupgrade**.
-   -  Instead, for x86 upgrades simply overwrite your virtual machine disk with a newly built vdisk image.
+   -  **OpenWRT 23.x and below**: If resizing partitions, attended sysupgrade returns the default partition schema - which will likely be a bad thing! Instead, for x86 upgrades you must recreate a new image and re-flash.
+   - **OpenWRT Version 24.x onwards**: Supports attended sysupgrade with a resized root partitions up to 1024mb (with a few extra config settings).
 
 ---
 
 ## ⚠️ WARNING: Resize of OpenWRT partitions on flash memory devices
-
-- **Parition resize should only be used with x86 builds**.
-  - Resize of firmware paritions on router hardware flash memory **will 99.99999% brick your device!!**
-    
-    
-- **For OpenWRT experts only**:
-    - Make sure you know what you are doing (you alter this script's protections and flash at your own risk).
+- **For bold OpenWRT experts only**:
+    - Parition resize should only be used with x86 builds. (The script needs to be manually edited to allow this)
+    - Make sure you know what you are doing (you edit or run this script at your own risk).
+    - Resize of firmware paritions on router hardware flash memory **will 99.99999% brick your device!!**
     - Have a plan to unbrick before proceeding.
-    - Understand you will no longer be able to use attended sysupgrade:
-      - Attended sysupgrade returns the default partition schema (which may likely be a bad thing).
-      - You must manually create all future upgrade images with the same resized partition schema via this script.
-
+      

--- a/x86-imagebuilder.sh
+++ b/x86-imagebuilder.sh
@@ -269,7 +269,7 @@ echo -e "${NC}"
 # Install OWRT build system dependencies for recent Ubuntu/Debian.
 # See here for other distro dependencies: https://openwrt.org/docs/guide-developer/toolchain/install-buildsystem
     sudo apt-get install -y build-essential clang flex bison g++ gawk gcc-multilib g++-multilib \
-    gettext git libncurses5-dev libssl-dev python3-distutils python3-setuptools rsync unzip zlib1g-dev file wget qemu-utils zstd  2>&1 | tee -a ${BUILD_LOG}
+    gettext git libncurses5-dev libssl-dev python3-setuptools rsync unzip zlib1g-dev file wget qemu-utils zstd  2>&1 | tee -a ${BUILD_LOG}
 
 # Download the image builder source if we haven't already
 if [ ! -f "${SOURCE_FILE}" ]; then


### PR DESCRIPTION
Hi,
I suggest to remove python3-distutils from the automatic package installation because of [PEP632](https://peps.python.org/pep-0632/)
Have a nice day !